### PR TITLE
ignore case sensitivity in filename extension

### DIFF
--- a/source/gba.cpp
+++ b/source/gba.cpp
@@ -8948,6 +8948,11 @@ static bool CPUIsGBABios(const char * file)
 
 		if(p != NULL)
 		{
+			char p_lower[strlen(p)];
+			for(int i = 0; i < strlen(p); i++)
+				p_lower[i] = tolower(p[i]);
+			p = p_lower;
+
 			if(strcasecmp(p, ".gba") == 0)
 				return true;
 			if(strcasecmp(p, ".agb") == 0)

--- a/source/memory.cpp
+++ b/source/memory.cpp
@@ -28,6 +28,11 @@ bool utilIsGBAImage(const char * file)
 
 		if(p != NULL)
       {
+		char p_lower[strlen(p)];
+		for(int i = 0; i < strlen(p); i++)
+			p_lower[i] = tolower(p[i]);
+		p = p_lower;
+
          if(
                !strcasecmp(p, ".agb") ||
                !strcasecmp(p, ".gba") ||


### PR DESCRIPTION
In issue https://github.com/RSDuck/vba-next-switch/issues/11 case insensitivity for the file extension was requested.

As I do not own a switch yet I could not verify the code.